### PR TITLE
feat: 예산안 평균값 조회 기능 구현

### DIFF
--- a/budgets/migrations/0004_base_average.py
+++ b/budgets/migrations/0004_base_average.py
@@ -1,0 +1,41 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+
+    dependencies = [("budgets", "0002_budget_total_budget")]
+
+    operations = [
+        migrations.RunSQL(
+            """
+            CREATE TABLE IF NOT EXISTS base_avg_cost (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                country VARCHAR(50) UNIQUE,
+                flight_avg INT,
+                insurance_avg INT,
+                visa_avg INT
+            );
+            """
+        ),
+
+        # --- 더미데이터 삽입(KRW 기준) ---
+        migrations.RunSQL(
+            """
+            INSERT INTO base_avg_cost(country, flight_avg, insurance_avg, visa_avg)
+            VALUES
+                ('미국', 1700000, 200000, 250000),
+                ('일본', 500000, 40000, 30000),
+                ('독일', 1600000, 220000, 240000),
+                ('프랑스', 1800000, 250000, 260000),
+                ('중국', 800000, 50000, 70000),
+                ('대만', 900000, 60000, 80000),
+                ('캐나다', 1500000, 230000, 260000),
+                ('이탈리아', 1400000, 210000, 230000),
+                ('네덜란드', 1600000, 220000, 250000),
+                ('영국', 1700000, 240000, 260000)
+            ON DUPLICATE KEY UPDATE
+                flight_avg = VALUES(flight_avg),
+                insurance_avg = VALUES(insurance_avg),
+                visa_avg = VALUES(visa_avg);
+            """
+        )
+    ]

--- a/budgets/migrations/0005_living_average.py
+++ b/budgets/migrations/0005_living_average.py
@@ -1,0 +1,39 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+
+    dependencies = [("budgets", "0004_base_average")]
+
+    operations = [
+        migrations.RunSQL(
+            """
+            CREATE TABLE IF NOT EXISTS living_avg_cost (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                country VARCHAR(50) UNIQUE,
+                transit_avg INT,
+                food_avg INT
+            );
+            """
+        ),
+
+        # --- 더미데이터 삽입(KRW 기준) ---
+        migrations.RunSQL(
+            """
+            INSERT INTO living_avg_cost(country, transit_avg, food_avg)
+            VALUES
+                ('미국', 100000, 500000),
+                ('일본', 60000, 400000),
+                ('독일', 90000, 550000),
+                ('프랑스', 100000, 600000),
+                ('중국', 50000, 350000),
+                ('대만', 40000, 300000),
+                ('캐나다', 90000, 550000),
+                ('이탈리아', 80000, 500000),
+                ('네덜란드', 110000, 600000),
+                ('영국', 120000, 650000)
+            ON DUPLICATE KEY UPDATE
+                transit_avg = VALUES(transit_avg),
+                food_avg = VALUES(food_avg);
+            """
+        )
+    ]

--- a/budgets/migrations/0006_total_average.py
+++ b/budgets/migrations/0006_total_average.py
@@ -1,0 +1,39 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+
+    dependencies = [("budgets", "0005_living_average")]
+
+    operations = [
+        migrations.RunSQL(
+            """
+            CREATE TABLE IF NOT EXISTS total_avg_cost (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                country VARCHAR(50) UNIQUE,
+                min_avg INT,
+                max_avg INT
+            );
+            """
+        ),
+
+        # --- 더미데이터 삽입(KRW 기준) ---
+        migrations.RunSQL(
+            """
+            INSERT INTO total_avg_cost(country, min_avg, max_avg)
+            VALUES
+                ('미국', 5000000, 20000000),
+                ('일본', 3000000, 12000000),
+                ('독일', 4000000, 15000000),
+                ('프랑스', 4500000, 16000000),
+                ('중국', 2500000, 9000000),
+                ('대만', 2200000, 8000000),
+                ('캐나다', 5000000, 18000000),
+                ('이탈리아', 4000000, 14000000),
+                ('네덜란드', 4500000, 16000000),
+                ('영국', 6000000, 20000000)
+            ON DUPLICATE KEY UPDATE
+                max_avg = VALUES(max_avg),
+                min_avg = VALUES(min_avg);
+            """
+        )
+    ]

--- a/budgets/urls.py
+++ b/budgets/urls.py
@@ -5,6 +5,7 @@ app_name = 'budgets'
 
 urlpatterns = [
     path('fill/', BudgetView.as_view(), name='budget-view'),
-    # path('base-budget/', BaseBudgetView.as_view(), name='base-budget-view'),
-    # path('living-budget/',LivingBudgetView.as_view(), name= 'living-budget-view')
+    path('base-average/', BaseAverageView.as_view(), name='base-average-view'),
+    path('living-average/',LivingAvgView.as_view(), name='living-average-view'),
+    path('total-average/', TotalAvgView.as_view(), name='total-average-view')
 ]

--- a/budgets/views.py
+++ b/budgets/views.py
@@ -6,6 +6,8 @@ from .models import *
 from .serializers import *
 from django.conf import settings
 from rest_framework import status
+from django.db import connection
+from accounts.models import ExchangeProfile
 
 # Create your views here.
 """
@@ -118,8 +120,116 @@ class LivingBudgetView(APIView):
         return Response(serializer.errors, status=400)
 
 
+#기본파견비 평균값 조회 
+class BaseAverageView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request):
+        profile = getattr(request.user, "exchange_profile", None)
+
+        if not profile or not profile.exchange_country:
+            return Response({"detail": "파견 국가 정보가 없습니다."}, status=400)
+
+        country = profile.exchange_country
+
+        sql = """
+            SELECT country, flight_avg, insurance_avg, visa_avg 
+            FROM base_avg_cost 
+            WHERE country = %s
+            LIMIT 1;
+        """
+
+        with connection.cursor() as cursor:
+            cursor.execute(sql, [country])
+            row = cursor.fetchone()
+
+        if not row:
+            return Response({"detail": "해당 국가의 평균값 정보가 없습니다."}, status=404)
+
+        return Response({
+            "country": row[0],
+            "flight_avg": row[1],
+            "insurance_avg": row[2],
+            "visa_avg": row[3],
+        })
+
 
     
+#생활비 평균값 조회
+class LivingAvgView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request):
+        user = request.user
+
+        # 유저 프로필에서 국가 가져오기
+        profile = getattr(user, "exchange_profile", None)
+        if not profile or not profile.exchange_country:
+            return Response({"detail": "사용자의 교환국가 정보가 없습니다."}, status=400)
+
+        country = profile.exchange_country 
+
+        # Raw SQL 실행
+        with connection.cursor() as cursor:
+            cursor.execute("""
+                SELECT transit_avg, food_avg
+                FROM living_avg_cost
+                WHERE country = %s
+            """, [country])
+
+            row = cursor.fetchone()
+
+        if not row:
+            return Response({"detail": f"{country}의 평균 데이터가 없습니다."}, status=404)
+
+        transit_avg, food_avg = row
+
+        return Response({
+            "country": country,
+            "transit_avg": transit_avg,
+            "food_avg": food_avg,
+        })
     
+#총 예상 비용 평균 조회
+def get_total_avg_cost(user):
+    profile = getattr(user, "exchange_profile", None)
+    if not profile:
+        return None
 
+    country = profile.exchange_country
 
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT min_avg, max_avg FROM total_avg_cost WHERE country = %s",
+            [country]
+        )
+        row = cursor.fetchone()
+
+    if not row:
+        return None
+
+    min_krw, max_krw = row
+
+    # 환산 통화 계산
+    target_currency = COUNTRY_TO_CURRENCY.get(country)
+
+    min_converted = convert_from_krw(min_krw, target_currency)
+    max_converted = convert_from_krw(max_krw, target_currency)
+
+    return {
+        "country": country,
+        "min_krw": min_krw,
+        "max_krw": max_krw,
+        "min_converted": min_converted,
+        "max_converted": max_converted,
+        "currency": target_currency,
+    }
+
+class TotalAvgView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request):
+        data = get_total_avg_cost(request.user)
+        if not data:
+            return Response({"detail": "데이터 없음"}, status=404)
+        return Response(data)


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->

- close #43 

## ✨ 작업 내용

<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->

- 예산안에서 사용되는 3가지 평균 비용(기본 파견비 / 생활비 / 전체 예산 평균) 조회 기능을 구현했습니다.

1) 모델 변경 없이 기능 추가
기존 모델 구조를 유지하기 위해,
migrations 파일에서 직접 테이블 생성 + 더미 데이터 삽입(INSERT) 방식으로 구현했습니다.
`base_avg_cost`, `living_avg_cost`, `total_avg_cost`
각 테이블은 나라별 파견 평균값을 저장하며, 실제 비즈니스 로직에는 영향을 주지 않습니다.

2) 더미 데이터 자동 삽입
각 마이그레이션 파일 내부에서
RunSQL을 사용해 테이블 생성과 동시에 기본 더미 데이터를 삽입하도록 구성했습니다.
배포 환경(AWS RDS)에서도 마이그레이션만 수행하면 동일하게 테이블 및 데이터가 생성됩니다.

3) 조회 로직
뷰에서 Django ORM을 사용하지 않고,
`connection.cursor()`를 이용해 직접 SQL 조회가 이루어집니다.
조회 기준은 현재 로그인한 user의 `ExchangeProfile` - `exchange_country` 입니다.


## 📸 Postman 테스트

<!-- 이미지 첨부 -->
1. 기본 예산안 평균
<img width="1274" height="550" alt="스크린샷 2025-11-26 오전 12 26 23" src="https://github.com/user-attachments/assets/bb4ca120-dd1c-4547-92c7-e571d93a03a9" />

2. 생활비 예산안 평균
<img width="1268" height="541" alt="스크린샷 2025-11-26 오전 12 26 41" src="https://github.com/user-attachments/assets/606f55b8-3b8a-4c05-8304-bfa2163e08d5" />

3. 총 예상 비용 min/max 평균
<img width="1271" height="588" alt="스크린샷 2025-11-26 오전 12 26 06" src="https://github.com/user-attachments/assets/4791a8ef-ce29-4f6a-87a3-347c6839b9ec" />

## ✅ 체크 리스트

- [x] main 브랜치 pull 완료
- [x] Assignees 설정
